### PR TITLE
docs: restructure AGENTS.md to match upstream template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,186 +1,117 @@
 # Woodland Development Guidelines
 
-## Project Overview
+Rules and principles for agents working on **this** project.
+
+---
+
+## 1. Core Rules
+
+### 1.0 Document Conventions
+
+When updating this document, append new information or sections. Do NOT delete or overwrite existing content unless explicitly directed. Always ask before making structural changes. When in doubt, keep it.
+
+### 1.1 Forbidden Patterns
+
+The following are **strictly prohibited**:
+
+- Hardcoded secrets, API keys, or credentials.
+- `eval()`, `exec()`, `vm.runInNewContext()` at any level.
+- `require()` with dynamic/user-controlled module paths.
+- `*` imports (`import * as x from "x"`).
+- Bypassing the auth middleware.
+
+### 1.2 Security Rules
+
+Follow the [OWASP Top 10](https://owasp.org/www-project-top-10/) for every piece of code written:
+
+- **Default Deny**: All security features default to restrictive settings (e.g., empty CORS origins)
+- **Input Validation**: Validate and sanitize all user input (headers, paths, parameters)
+- **Output Encoding**: Escape all output to prevent XSS attacks
+- **Path Traversal Protection**: Use `resolve()` + `startsWith()` for file path validation
+- **Header Injection Prevention**: Type-check header values (string or number only)
+- **Prototype Pollution Protection**: Use `Object.hasOwn()` before accessing object properties
+- **Open Redirect Prevention**: Block protocol schemes and control characters in redirects
+- **Origin Sanitization**: Use `#isSafeOrigin()` to validate Origin headers before using in CORS responses (block control chars, enforce scheme, limit length)
+- **Error Message Containment**: By default, error responses only send HTTP status text, not internal messages or stack traces
+- **Body Size Limiting**: Middleware rejects requests exceeding `bodyLimit` with 413 to prevent DoS
+- **TRACE Disabled by Default**: TRACE method disabled by default (`disableTrace: true`) to prevent XST attacks — enable with `disableTrace: false` in config
+
+### 1.3 Git Operations
+
+- **Never rebase under any circumstance without explicit agreement from the user.** Never assume your decision is correct.
+- Never force push.
+
+### 1.4 Core Principles
+
+- **DRY**: Extract repeated logic into functions, classes, or utilities. Reuse common logic throughout the codebase. No copy-paste code blocks greater than three lines.
+- **KISS**: Prefer simple, readable code over clever solutions.
+- **YAGNI**: Do NOT build features, abstractions, or configurations not required by the current spec. No generic "future-proof" wrappers. Ad-hoc solutions are acceptable as long as they serve a present requirement.
+- **Single Responsibility**: Each module, class, and function must have one reason to change.
+- **Open/Closed**: Extend via composition — not by modifying existing logic.
+- **Dependency Inversion**: Depend on abstractions for external services. Inject implementations.
+- **No Magic Values**: All numeric literals and string literals must use constants from `constants.js`.
+
+---
+
+## 2. Project Context
 
 Woodland is a high-performance HTTP framework for Node.js. This document provides context for AI agents working on the codebase.
 
-## Guiding Principles
+### 2.0 Expected Project Layout
 
-### Security-First Design
-
-1. **Default Deny**: All security features default to restrictive settings (e.g., empty CORS origins)
-2. **Input Validation**: Validate and sanitize all user input (headers, paths, parameters)
-3. **Output Encoding**: Escape all output to prevent XSS attacks
-4. **Path Traversal Protection**: Use `resolve()` + `startsWith()` for file path validation
-5. **Header Injection Prevention**: Type-check header values (string or number only)
-6. **Prototype Pollution Protection**: Use `Object.hasOwn()` before accessing object properties
-7. **Open Redirect Prevention**: Block protocol schemes and control characters in redirects
-8. **Origin Sanitization**: Use `#isSafeOrigin()` to validate Origin headers before using in CORS responses (block control chars, enforce scheme, limit length)
-9. **Error Message Containment**: By default, error responses only send HTTP status text, not internal messages or stack traces
-10. **Body Size Limiting**: Middleware rejects requests exceeding `bodyLimit` with 413 to prevent DoS
-11. **TRACE Disabled by Default**: TRACE method disabled by default (`disableTrace: true`) to prevent XST attacks — enable with `disableTrace: false` in config
-
-### Code Quality Principles
-
-1. **DRY (Don't Repeat Yourself)**: Extract common logic into reusable functions
-2. **YAGNI (You Aren't Gonna Need It)**: Avoid adding features without clear requirements
-3. **SOLID Principles**:
-   - Single Responsibility: Each module has one purpose
-   - Open/Closed: Open for extension, closed for modification
-   - Liskov Substitution: Subtypes must be substitutable for base types
-   - Interface Segregation: Prefer small, focused interfaces
-   - Dependency Inversion: Depend on abstractions, not concretions
-4. **OWASP Compliance**: Follow OWASP Top 10 guidelines for web security
-5. **No Magic Values**: All numeric literals and string literals must use constants
-
-### Performance Principles
-
-1. **Zero Overhead Security**: Security features must have minimal performance impact
-2. **LRU Caching**: Cache expensive operations (routes, permissions, ETags)
-3. **Iterator Pattern**: Use iterators for middleware chains to avoid array copies
-4. **Batch Operations**: Group header operations to reduce function calls
-5. **Event Loop Scheduling**: Use `process.nextTick()` for non-blocking operations
-
-### Testing Principles
-
-1. **100% Line Coverage**: All code paths must be tested
-2. **Security Testing**: Dedicated tests for security features
-3. **Edge Cases**: Test boundary conditions and error paths
-4. **Integration Tests**: Verify component interactions
-5. **No Flaky Tests**: All tests must be deterministic
-
-### Documentation Principles
-
-1. **Accuracy**: Documentation must match implementation exactly
-2. **Completeness**: Document all public APIs with JSDoc
-3. **Examples**: Provide working code examples
-4. **Security Notes**: Highlight security considerations
-5. **No Unverified Claims**: Remove performance claims without benchmarks
-
-## Architecture
-
-### Core Files
-
-- **`src/woodland.js`**: Main HTTP server framework class extending EventEmitter
-- **`src/middleware.js`**: Middleware registry and routing logic
-- **`src/request.js`**: Request parsing, IP extraction, CORS handling
-- **`src/response.js`**: Response handlers, MIME types, streaming
-- **`src/fileserver.js`**: Static file serving with directory indexing
-- **`src/logger.js`**: Logging utilities with configurable format/level
-- **`src/config.js`**: Configuration validation using jsonschema
-- **`src/constants.js`**: HTTP constants, status codes, headers
-- **`src/cli.js`**: CLI entry point for running the framework
-
-### Type Definitions
-
-- **`types/woodland.d.ts`**: TypeScript definitions for the public API
-
-### Testing
-
-- **`tests/unit/`**: Unit tests for individual modules
-- **`tests/integration/`**: Integration tests
-- **`tests/test-files/`**: Test fixtures
-
-### Benchmarks
-
-- **`benchmarks/`**: Performance comparison tests
-
-## Public API
-
-### Factory Function
-
-```javascript
-import { woodland } from "woodland";
-const app = woodland(config);
+```
+.
+├── src/                    # Core framework source files
+│   ├── woodland.js         # Main HTTP server framework class extending EventEmitter
+│   ├── middleware.js       # Middleware registry and routing logic
+│   ├── request.js          # Request parsing, IP extraction, CORS handling
+│   ├── response.js         # Response handlers, MIME types, streaming
+│   ├── fileserver.js       # Static file serving with directory indexing
+│   ├── logger.js           # Logging utilities with configurable format/level
+│   ├── config.js           # Configuration validation using jsonschema
+│   ├── constants.js        # HTTP constants, status codes, headers
+│   └── cli.js              # CLI entry point for running the framework
+├── types/                  # TypeScript definitions for the public API
+│   └── woodland.d.ts
+├── tests/                  # Test files
+│   ├── unit/               # Unit tests for individual modules
+│   ├── integration/        # Integration tests
+│   └── test-files/         # Test fixtures
+├── benchmarks/             # Performance comparison tests
+└── package.json
 ```
 
-### Woodland Class Methods
+### 2.1 Quick Commands
 
-#### Routing Methods (all return `Woodland` for chaining)
+| Command          | Purpose                        |
+|------------------|--------------------------------|
+| `npm test`       | Full test suite with lint (100% line coverage) |
+| `npm run test:watch` | Watch mode                 |
+| `npm run coverage`   | Generate coverage report   |
+| `npm run build`    | Generate dist files        |
 
-- `get(rpath, ...fn)` - GET route
-- `post(rpath, ...fn)` - POST route
-- `put(rpath, ...fn)` - PUT route
-- `delete(rpath, ...fn)` - DELETE route
-- `patch(rpath, ...fn)` - PATCH route
-- `options(rpath, ...fn)` - OPTIONS route
-- `connect(rpath, ...fn)` - CONNECT route
-- `trace(rpath, ...fn)` - TRACE route (disabled by default, requires `disableTrace: false`)
-- `always(rpath, ...fn)` - All methods (wildcard)
+---
 
-#### Middleware Methods
+## 3. JavaScript/TypeScript Conventions
 
-- `use(rpath, ...fn)` - Register middleware (last arg can be method string)
-- `ignore(fn)` - Add function to ignored set
-- `list(method, type)` - List routes (returns array or object)
+### 3.1 Language & Tooling
 
-#### File Serving
+- **JavaScript**: ES modules (import/export)
+- **Package manager**: npm
+- **Type checking**: TypeScript definitions in `types/woodland.d.ts`
+- **Testing**: Node.js built-in test runner via npm scripts
+- **Linting**: Lint enforced via `npm test`
 
-- `files(root, folder)` - Register file server middleware
-- `serve(req, res, arg, folder)` - Serve file from disk (async)
-- `stream(req, res, file)` - Stream file to response
-
-#### Utilities
-
-- `etag(method, ...args)` - Generate ETag for caching
-- `route(req, res)` - Main request handler
-- `routes(uri, method, override)` - Get route information
-- `logger` - Logger instance (getter only)
-
-### Configuration Options
-
-All optional in constructor:
-
-```typescript
-{
-  autoIndex?: boolean;      // Enable directory indexing (default: false)
-  bodyLimit?: number;       // Max request body size in bytes (default: 10000000 = 10MB)
-  cacheSize?: number;       // Cache size (default: 1000)
-  cacheTTL?: number;        // Cache TTL in ms (default: 10000)
-  charset?: string;         // Default charset (default: 'utf-8')
-  corsExpose?: string;      // CORS expose headers (default: '')
-  defaultHeaders?: Record<string, string>; // Default headers
-  disableTrace?: boolean;   // Disable TRACE method (default: true, prevents XST)
-  digit?: number;           // Timing precision (default: 3)
-  etags?: boolean;          // Enable ETags (default: true)
-  exposeErrorMessages?: boolean; // Expose internal error messages (default: false)
-  indexes?: string[];       // Index files (default: ['index.htm','index.html'])
-  logging?: object;         // Logging config
-  origins?: string[];       // Allowed CORS origins (default: [])
-  silent?: boolean;         // Silent mode (default: false)
-  time?: boolean;           // Enable timing (default: false)
-}
-```
-
-## Internals (Avoid Modifying Unless Necessary)
-
-### Private Fields (using #)
-
-- `#autoIndex`, `#bodyLimit`, `#charset`, `#corsExpose`, `#defaultHeaders`
-- `#disableTrace`, `#digit`, `#etags`, `#exposeErrorMessages`, `#indexes`, `#logging`
-- `#origins`, `#time`, `#cache`
-- `#methods`, `#logger`, `#fileServer`, `#middleware`
-
-### Private Methods
-
-- `#allows()`, `#buildAllowedList()`
-- `#decorate()`, `#addCorsHeaders()`
-- `#isSafeOrigin()`, `#setCorsAllowAndExposeHeaders()`
-- `#onDone()`, `#onReady()`, `#onSend()`
-- `#handleAllowedRoute()`
-- `#registerMethod()` - Register middleware for a given HTTP method
-- `#setupBodyLimit()` - Body size limit middleware
-
-## Code Style
+### 3.2 Style
 
 - Use ES modules (import/export)
-- Private fields with `#` prefix
+- Private class fields with `#` prefix
 - JSDoc comments for all public APIs
 - Parameter tables in documentation with optional markers
 - Follow existing patterns in tests
-- **Use constants instead of magic strings or numbers** - Define all string literals and numeric values as constants in `constants.js`
+- **Use constants instead of magic strings or numbers** — define all string literals and numeric values as constants in `constants.js`
 
-### Constants Pattern
+### 3.3 Constants Pattern
 
 All numeric literals and string literals must use constants from `constants.js`:
 
@@ -211,23 +142,102 @@ if (typeof fn === "function") { ... }
 const x = array[0];
 ```
 
-**Regex with 'g' modifier should NOT be constants** - they maintain state and can cause issues when reused.
+**Regex with 'g' modifier should NOT be constants** — they maintain state and can cause issues when reused.
 
-## Running Tests
+---
 
-```bash
-npm test              # Full test suite with lint (100% line coverage)
-npm run test:watch    # Watch mode
-npm run coverage      # Generate coverage report
+## 4. Framework Conventions
+
+### 4.1 Factory Function
+
+```javascript
+import { woodland } from "woodland";
+const app = woodland(config);
 ```
 
-**Test Requirements:**
-- All 335 tests must pass
-- 100% line coverage required
-- Run `npm test` before committing
-- Run `npm run build` before pushing (generates dist files)
+### 4.2 Routing Methods (all return `Woodland` for chaining)
 
-## Key Design Patterns
+- `get(rpath, ...fn)` - GET route
+- `post(rpath, ...fn)` - POST route
+- `put(rpath, ...fn)` - PUT route
+- `delete(rpath, ...fn)` - DELETE route
+- `patch(rpath, ...fn)` - PATCH route
+- `options(rpath, ...fn)` - OPTIONS route
+- `connect(rpath, ...fn)` - CONNECT route
+- `trace(rpath, ...fn)` - TRACE route (disabled by default, requires `disableTrace: false`)
+- `always(rpath, ...fn)` - All methods (wildcard)
+
+### 4.3 Middleware Method
+
+- `use(rpath, ...fn)` - Register middleware (last arg can be method string)
+
+### 4.4 File Serving
+
+- `files(root, folder)` - Register file server middleware
+- `serve(req, res, arg, folder)` - Serve file from disk (async)
+- `stream(req, res, file)` - Stream file to response
+
+### 4.5 Configuration
+
+All optional in constructor:
+
+- `autoIndex?: boolean` — Enable directory indexing (default: false)
+- `bodyLimit?: number` — Max request body size in bytes (default: 10000000 = 10MB)
+- `cacheSize?: number` — Cache size (default: 1000)
+- `cacheTTL?: number` — Cache TTL in ms (default: 10000)
+- `charset?: string` — Default charset (default: 'utf-8')
+- `corsExpose?: string` — CORS expose headers (default: '')
+- `defaultHeaders?: Record<string, string>` — Default headers
+- `disableTrace?: boolean` — Disable TRACE method (default: true, prevents XST)
+- `digit?: number` — Timing precision (default: 3)
+- `etags?: boolean` — Enable ETags (default: true)
+- `exposeErrorMessages?: boolean` — Expose internal error messages (default: false)
+- `indexes?: string[]` — Index files (default: ['index.htm','index.html'])
+- `logging?: object` — Logging config
+- `origins?: string[]` — Allowed CORS origins (default: [])
+- `silent?: boolean` — Silent mode (default: false)
+- `time?: boolean` — Enable timing (default: false)
+
+---
+
+## 5. Git Conventions
+
+### 5.1 Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new static file serving feature
+fix: correct CORS header handling for edge cases
+docs: update AGENTS.md with new structure
+test: add tests for path traversal protection
+chore: update dependencies
+```
+
+### 5.2 Branching
+
+- Main branch is `master`.
+- Feature branches: `feat/<short-desc>` or `fix/<short-desc>`.
+- Never commit directly to `master`. Always create a feature branch first, then open a PR targeting `master`.
+
+### 5.3 Build Requirements
+
+- Run `npm test` before committing (all 335 tests must pass, 100% line coverage required).
+- Run `npm run build` before pushing (generates dist files).
+
+---
+
+## 6. Operational Rules
+
+### 6.1 Performance Principles
+
+- **Zero Overhead Security**: Security features must have minimal performance impact
+- **LRU Caching**: Cache expensive operations (routes, permissions, ETags)
+- **Iterator Pattern**: Use iterators for middleware chains to avoid array copies
+- **Batch Operations**: Group header operations to reduce function calls
+- **Event Loop Scheduling**: Use `process.nextTick()` for non-blocking operations
+
+### 6.2 Key Design Patterns
 
 1. **Middleware Chain**: Uses iterator pattern with `next()` function
 2. **Request Decoration**: Request/response objects decorated with utilities
@@ -237,23 +247,79 @@ npm run coverage      # Generate coverage report
 6. **File Serving**: Automatic MIME types, range requests, directory indexing
 7. **Constants-First**: All literals defined as constants for maintainability
 
-## Events
+### 6.3 Events
 
-- `error` - Error occurred: `(req, res, error)`
-- `connect` - Request connected: `(req, res)`
-- `finish` - Response finished: `(req, res)`
-- `stream` - File streaming started: `(req, res)`
+- `error` — Error occurred: `(req, res, error)`
+- `connect` — Request connected: `(req, res)`
+- `finish` — Response finished: `(req, res)`
+- `stream` — File streaming started: `(req, res)`
 
-## Request/Response Decorations
+### 6.4 Request/Response Decorations
 
-### Request Properties
+#### Request Properties
 
 - `req.corsHost`, `req.cors`, `req.parsed`, `req.allow`
 - `req.ip`, `req.body`, `req.host`, `req.params`
 - `req.valid`, `req.precise`
 
-### Response Methods
+#### Response Methods
 
 - `res.error()`, `res.header()`, `res.json()`
 - `res.redirect()`, `res.send()`, `res.set()`
 - `res.status()`, `res.locals`
+
+### 6.5 Coverage
+
+The test suite enforces **100% line coverage**. Every new function or class needs test coverage. No exceptions.
+
+```bash
+npm run coverage   # Generate coverage report
+npm test           # Full test suite with lint (100% line coverage)
+```
+
+### 6.6 Utility Methods
+
+- `ignore(fn)` — Add function to ignored set
+- `list(method, type)` — List routes (returns array or object)
+- `etag(method, ...args)` — Generate ETag for caching
+- `route(req, res)` — Main request handler
+- `routes(uri, method, override)` — Get route information
+- `logger` — Logger instance (getter only)
+
+---
+
+## 7. Session Learnings
+
+Discovery notes about the codebase.
+
+### 7.1 Internals (Avoid Modifying Unless Necessary)
+
+The following private fields and methods are part of the internal implementation and should be avoided unless necessary:
+
+**Private Fields (using #):**
+- `#autoIndex`, `#bodyLimit`, `#charset`, `#corsExpose`, `#defaultHeaders`
+- `#disableTrace`, `#digit`, `#etags`, `#exposeErrorMessages`, `#indexes`, `#logging`
+- `#origins`, `#time`, `#cache`
+- `#methods`, `#logger`, `#fileServer`, `#middleware`
+
+**Private Methods:**
+- `#allows()`, `#buildAllowedList()`
+- `#decorate()`, `#addCorsHeaders()`
+- `#isSafeOrigin()`, `#setCorsAllowAndExposeHeaders()`
+- `#onDone()`, `#onReady()`, `#onSend()`
+- `#handleAllowedRoute()`
+- `#registerMethod()` — Register middleware for a given HTTP method
+- `#setupBodyLimit()` — Body size limit middleware
+
+---
+
+## 8. Checklist Before Marking a TODO Complete
+
+- [ ] All code follows existing conventions (ES modules, private fields with `#`, JSDoc).
+- [ ] Constants from `constants.js` used instead of magic values.
+- [ ] Unit tests written and passing.
+- [ ] 100% code coverage maintained (enforced by `npm test`).
+- [ ] No hardcoded secrets or credentials introduced.
+- [ ] Security principles followed (OWASP compliance, default deny, input validation).
+- [ ] `npm test` passes before committing.
+- [ ] `npm run build` passes before pushing.


### PR DESCRIPTION
---

- Restructure `AGENTS.md` to match the [avoidwork/AGENTS.md](https://raw.githubusercontent.com/avoidwork/AGENTS.md/refs/heads/main/AGENTS.md) template structure
- Fix forbidden patterns section: removed Python-specific `__import__()`, replaced with JS/Node equivalents
- Fixed branching section: changed `main` references to `master` (project uses `master` as main branch)

## Changes

- Reorganized from flat sections into structured sections (Core Rules, Project Context, Conventions, Framework, Git, Operational Rules, Session Learnings, Checklist)
- Adapted all content to be JavaScript/Node.js-specific
- Maintained all existing project knowledge and conventions