### PR TITLE
spec: add global error handler via app.error property

### DIFF
--- a/openspec/changes/add-error-property/.openspec.yaml
+++ b/openspec/changes/add-error-property/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/add-error-property/design.md
+++ b/openspec/changes/add-error-property/design.md
@@ -1,0 +1,84 @@
+---
+description: Technical design for adding the 'error' property to Woodland and wiring it through the middleware chain.
+---
+
+# design.md
+
+## Context
+
+- The `Woodland` class lives in `src/woodland.js` and uses private fields (e.g., `#error`)
+- The `#decorate` method sets `req.app` to a minimal stub: `{ get: (key) => (key === "trust proxy" ? false : undefined) }` at line 349
+- The `next` function in `src/middleware.js` handles middleware execution and error handling via `handleError` and `handleMiddleware`
+- Error handlers are identified by having `ERROR_HANDLER_LENGTH` (4) arguments
+
+## Changes
+
+### 1. Add `#error` private field to `Woodland` class
+
+Add a new private field:
+```javascript
+#error;
+```
+
+Initialize it in the constructor:
+```javascript
+this.#error = null;
+```
+
+Add a getter-only property:
+```javascript
+get error() {
+    return this.#error;
+}
+```
+
+The property will accept either `null` or a function. Since this is a getter/setter pattern, users can assign a function to `app.error`.
+
+### 2. Update `#decorate` to set `req.app = this`
+
+Replace the current inline object at line 349:
+```javascript
+// Before
+req.app = { get: (key) => (key === "trust proxy" ? false : undefined) };
+
+// After
+req.app = this;
+```
+
+This makes the full Woodland instance accessible via `req.app`, including the `error` property.
+
+### 3. Update `execute` in `middleware.js` to call `req.app.error`
+
+In the `next` function, when an error occurs (the `execute` function is called with an error, or `handleError` is called), check if `req.app.error` exists and is a function before handling the error. If it exists, call it with the error and request/response context:
+
+```javascript
+const execute = (err) => {
+    if (err !== void 0) {
+        // Check for global error handler on the app instance
+        if (typeof req.app?.error === FUNCTION) {
+            req.app.error(err, req, res, execute);
+        } else {
+            handleError(err, execute);
+        }
+    } else {
+        handleMiddleware(execute);
+    }
+};
+```
+
+This checks `req.app.error` before falling back to the existing error middleware chain (`handleError`).
+
+## Design Decisions
+
+1. **Setter vs. Private Field**: The `error` property uses a getter/setter so it can be freely assigned by users. The private `#error` field stores the value.
+
+2. **`req.app = this`**: Giving full access to the Woodland instance via `req.app` is the cleanest approach since it provides the `error` reference without additional indirection. This aligns with Express's `req.app` convention.
+
+3. **Error handler signature**: The global error handler uses the same signature as error middleware: `(err, req, res, next)`, making it consistent with the framework's error handling model.
+
+4. **Priority**: The global `req.app.error` is checked before the error middleware chain, giving users a single override point for all unhandled errors.
+
+## Security
+
+- The `error` property must be a function or `null` — no security concerns with type acceptance
+- No new attack surface is introduced

--- a/openspec/changes/add-error-property/design.md
+++ b/openspec/changes/add-error-property/design.md
@@ -25,14 +25,18 @@ Initialize it in the constructor:
 this.#error = null;
 ```
 
-Add a getter-only property:
+Add a getter/setter property:
 ```javascript
 get error() {
     return this.#error;
 }
+
+set error(fn) {
+    this.#error = typeof fn === FUNCTION ? fn : null;
+}
 ```
 
-The property will accept either `null` or a function. Since this is a getter/setter pattern, users can assign a function to `app.error`.
+The property accepts either `null` or a function. Users can assign a function to `app.error`.
 
 ### 2. Update `#decorate` to set `req.app = this`
 
@@ -49,24 +53,23 @@ This makes the full Woodland instance accessible via `req.app`, including the `e
 
 ### 3. Update `execute` in `middleware.js` to call `req.app.error`
 
-In the `next` function, when an error occurs (the `execute` function is called with an error, or `handleError` is called), check if `req.app.error` exists and is a function before handling the error. If it exists, call it with the error and request/response context:
+In the `next` function, when an error occurs, check if `req.app.error` exists and is a function before handling the error. If it exists, call it with `(err, req, res)` — only 3 parameters. The error handler is responsible for terminating the request. If the handler is not set, fall back to the existing error middleware chain:
 
 ```javascript
 const execute = (err) => {
     if (err !== void 0) {
-        // Check for global error handler on the app instance
         if (typeof req.app?.error === FUNCTION) {
-            req.app.error(err, req, res, execute);
-        } else {
-            handleError(err, execute);
+            req.app.error(err, req, res);
+            return;
         }
+        handleError(err, execute);
     } else {
         handleMiddleware(execute);
     }
 };
 ```
 
-This checks `req.app.error` before falling back to the existing error middleware chain (`handleError`).
+The `return` after calling `req.app.error` ensures the error middleware chain is skipped — the global handler has full responsibility for terminating the request.
 
 ## Design Decisions
 
@@ -74,7 +77,7 @@ This checks `req.app.error` before falling back to the existing error middleware
 
 2. **`req.app = this`**: Giving full access to the Woodland instance via `req.app` is the cleanest approach since it provides the `error` reference without additional indirection. This aligns with Express's `req.app` convention.
 
-3. **Error handler signature**: The global error handler uses the same signature as error middleware: `(err, req, res, next)`, making it consistent with the framework's error handling model.
+3. **Error handler signature**: The global error handler uses a 3-argument signature: `(err, req, res)`. No `next` argument is provided — the handler must terminate the request itself (e.g., by calling `res.error()`, `res.send()`, etc.).
 
 4. **Priority**: The global `req.app.error` is checked before the error middleware chain, giving users a single override point for all unhandled errors.
 

--- a/openspec/changes/add-error-property/proposal.md
+++ b/openspec/changes/add-error-property/proposal.md
@@ -1,0 +1,26 @@
+---
+description: Add an 'error' property to the Woodland class that allows users to set a global error handler function. Updated to set 'req.app = this' in '#decorate' so 'req.app.error' can be accessed from middleware.
+---
+
+# proposal.md
+
+## Why
+
+Currently, the Woodland framework does not provide a way to set a global error handler at the application level. Error handling is limited to per-route error middleware (4-argument functions). Users cannot intercept unhandled errors globally via a simple assignment.
+
+## What Changes
+
+1. Add an `error` property to the `Woodland` class that defaults to `null` with type `null | function`.
+2. Update the `#decorate` method to set `req.app = this` instead of the current inline app stub, so the app instance is accessible from the request object.
+3. Update the `execute` function in `middleware.js` to check for `req.app.error` and call it if it's not null before falling back to existing error handling behavior.
+
+## Impact
+
+- **Modified**: `src/woodland.js` — add `#error` private field, public getter/setter, update `#decorate` to assign `req.app = this`
+- **Modified**: `src/middleware.js` — update `execute` in the `next` function to call `req.app.error` when an error occurs
+
+## Benefits
+
+- Users can set a global error handler: `app.error = (err, req, res, next) => { ... }`
+- Consistent with the existing `res.error()` pattern
+- Enables centralized error logging, reporting, or custom error responses

--- a/openspec/changes/add-error-property/tasks.md
+++ b/openspec/changes/add-error-property/tasks.md
@@ -1,0 +1,57 @@
+---
+description: Implementation tasks for adding the 'error' property to Woodland
+---
+
+# tasks.md
+
+## 1. Add `#error` private field to Woodland class
+
+- [ ] 1.1 Add `#error;` private field declaration after existing private fields in `src/woodland.js`
+- [ ] 1.2 Initialize `this.#error = null;` in the constructor
+- [ ] 1.3 Add getter `get error() { return this.#error; }` and setter `set error(fn) { this.#error = typeof fn === FUNCTION ? fn : null; }` at the end of the class before the closing brace
+
+## 2. Update `#decorate` to set `req.app = this`
+
+- [ ] 2.1 In `src/woodland.js`, replace the existing `req.app` assignment in `#decorate` (line 349):
+    ```
+    req.app = { get: (key) => (key === "trust proxy" ? false : undefined) };
+    ```
+    with:
+    ```
+    req.app = this;
+    ```
+
+## 3. Update `execute` in middleware.js to call `req.app.error`
+
+- [ ] 3.1 In `src/middleware.js`, update the `execute` function inside `next()`:
+    ```javascript
+    const execute = (err) => {
+        if (err !== void 0) {
+            if (typeof req.app?.error === FUNCTION) {
+                req.app.error(err, req, res, execute);
+            } else {
+                handleError(err, execute);
+            }
+        } else {
+            handleMiddleware(execute);
+        }
+    };
+    ```
+
+## 4. Update TypeScript definitions
+
+- [ ] 4.1 In `types/woodland.d.ts`, add the `error` property to the Woodland class interface with type `((err: Error, req: import("./woodland").Request, res: import("./woodland").Response, next: Function) => void) | undefined`
+
+## 5. Update existing tests and add new tests
+
+- [ ] 5.1 Update any unit tests that reference `req.app` to expect the Woodland instance instead of the stub object
+- [ ] 5.2 Add test for `app.error = null` (default state)
+- [ ] 5.3 Add test for setting `app.error` to a function and verifying it is called on error
+- [ ] 5.4 Add test for error handler being called before error middleware chain
+- [ ] 5.5 Add test for error handler not being called when it equals null/default
+- [ ] 5.6 Ensure 100% line coverage is maintained
+
+## 6. Build and run tests
+
+- [ ] 6.1 Run `npm test` and ensure all tests pass with 100% coverage
+- [ ] 6.2 Run `npm run build` and ensure build succeeds

--- a/openspec/changes/add-error-property/tasks.md
+++ b/openspec/changes/add-error-property/tasks.md
@@ -28,10 +28,10 @@ description: Implementation tasks for adding the 'error' property to Woodland
     const execute = (err) => {
         if (err !== void 0) {
             if (typeof req.app?.error === FUNCTION) {
-                req.app.error(err, req, res, execute);
-            } else {
-                handleError(err, execute);
+                req.app.error(err, req, res);
+                return;
             }
+            handleError(err, execute);
         } else {
             handleMiddleware(execute);
         }
@@ -40,7 +40,7 @@ description: Implementation tasks for adding the 'error' property to Woodland
 
 ## 4. Update TypeScript definitions
 
-- [ ] 4.1 In `types/woodland.d.ts`, add the `error` property to the Woodland class interface with type `((err: Error, req: import("./woodland").Request, res: import("./woodland").Response, next: Function) => void) | undefined`
+- [ ] 4.1 In `types/woodland.d.ts`, add the `error` property to the Woodland class interface with type `((err: Error, req: import("./woodland").Request, res: import("./woodland").Response) => void) | undefined`
 
 ## 5. Update existing tests and add new tests
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## What

Add an `error` property to the Woodland class that allows users to set a global error handler function.

### Changes
- Add `#error` private field with getter/setter (type: `null | function`)
- Update `#decorate` to set `req.app = this` instead of inline stub
- Update `execute` in middleware.js to call `req.app.error` before falling back to error middleware chain

### Artifacts
- `proposal.md` — Why users need a global error handler
- `design.md` — Technical design details
- `tasks.md` — Implementation tasks

Run `/opsx-apply` to implement.